### PR TITLE
Remove misleading statement from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ Please look at the [homepage](http://www.ror-e.com) for more details.
 
 ![RoR Ecommerce](http://ror-e.com/images/logo.png "ROR Ecommerce").
 
-This is a Rails e-commerce platform. Other e-commerce projects that use rails don't use rails in a standard way.
-They use engines or are a separate framework altogether.
-
 ROR Ecommerce is a *Rails 3 application* with the intent to allow developers to create an ecommerce solution easily.
 This solution includes an Admin for *Purchase Orders*, *Product creation*, *Shipments*, *Fulfillment* and *creating Orders*.
 There is a minimal customer facing shopping cart understanding that this will be customized.


### PR DESCRIPTION
Remove statement that Engines and frameworks are nonstandard ways of
using Ruby on Rails. Engines are Rails applications themselves, and
using frameworks/gems is hardly nonstandard; most Ruby and Rails
applications do.

Signed-off-by: David Celis david@davidcelis.com
