### PR TITLE
Changes admin config countries to display only active countries

### DIFF
--- a/app/assets/javascripts/admin/countries.js
+++ b/app/assets/javascripts/admin/countries.js
@@ -1,0 +1,10 @@
+jQuery(document).ready(function ($) {
+  var selected = 1;
+  $countries_select = $('#countries_select');
+  $countries_select.on('change', function(){
+    selected = $countries_select.val();
+    var $link = $('#activate-link');
+    var url = $link.attr('href').replace(/(\/+[0-9]{1,9})$/, "/"+selected);
+    $link.attr('href', url).click();
+  })
+});

--- a/app/controllers/admin/config/countries_controller.rb
+++ b/app/controllers/admin/config/countries_controller.rb
@@ -1,7 +1,8 @@
 class Admin::Config::CountriesController < Admin::Config::BaseController
   helper_method :sort_column, :sort_direction
   def index
-    @countries = Country.order(sort_column + " " + sort_direction).
+    @countries = Country.order(sort_column + " " + sort_direction)
+    @active_countries = Country.active_countries.order(sort_column + " " + sort_direction).
                                               paginate(:page => pagination_page, :per_page => pagination_rows)
   end
 

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -7,6 +7,9 @@ class Country < ActiveRecord::Base
   validates :name,  :presence => true,       :length => { :maximum => 200 }
   validates :abbreviation,  :presence => true,       :length => { :maximum => 10 }
 
+  scope :active_countries, where(:active => true)
+  scope :inactive_countries, where(:active => false)
+
   USA_ID    = 214
   CANADA_ID = 35
 

--- a/app/views/admin/config/countries/index.html.erb
+++ b/app/views/admin/config/countries/index.html.erb
@@ -1,9 +1,13 @@
 <% content_for :head do -%>
-
+  <%= javascript_include_tag 'admin/countries' %>
 <% end %>
 
 <h1> Countries </h1>
-
+<p>
+  Select other countries below to activate them:
+  <%= select_tag "countries_select", options_from_collection_for_select(@countries, "id", "name") %>
+  <%= link_to "Ativar", [:admin, :config, @countries.first], method: :put, id: "activate-link", style: "display:none;" %>
+</p>
 <div id="admin_country_grid_wrapper" class='pretty_table'>
   <table>
     <tr class='odd'>
@@ -14,22 +18,17 @@
         <th></th>
     </tr>
     <tbody>
-    <% for country in @countries %>
+    <% for country in @active_countries %>
       <tr  class='<%= cycle("odd", "")%>'>
           <td><%= country.name %></td>
           <td><%= country.abbreviation %></td>
           <td><%= country.shipping_zone.try(:name) %></td>
-          <td><%= country.active %></td>
-        <% if country.active? %>
           <td><%= link_to "InActivate", [:admin, :config, country], :data => { :confirm => 'Are you sure?' }, :method => :delete %></td>
-        <% else %>
-          <td><%= link_to "Activate", [:admin, :config, country], :data => { :confirm => 'Are you sure?' }, :method => :put %></td>
-        <% end %>
       </tr>
     <% end %>
     </tbody>
   </table>
 </div>
 
-<%= will_paginate @countries %>
+<%= will_paginate @active_countries %>
 


### PR DESCRIPTION
I didn't like to have all of the countries in a paginated list, it was slow to find the country I wanted, so I came up with this approach:
The countries page will show up on the list only the active countries - with link to deactivate them - and there is a select_tag with all of the countries where you can just select a country and it'll be activated.
It is much faster that way =)
