### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-###2.1.0
+### 2.1.0
 * RAILS 4.2
 * Remove statemachine in favor of AASM
 * upgrade many gems (including rspec)
 * RUBY 2.1.5
 * Security fix for POSTGRES
 
-###2.0.1
+### 2.0.1
 * RAILS 4.0.4
 * upgrade gems
 * autofill more on checkout
@@ -15,12 +15,12 @@
 * merge carts after signing in
 * better UI
 
-###2.0.0beta1
+### 2.0.0beta1
 
 * RAILS 4.0.0.rc1 YEAH BABY!
 * RUBY 2.0 WOW!!
 
-###1.5.0 2013-04-19
+### 1.5.0 2013-04-19
 * confirmation page for GA
 * referrals
 * reporting tab in admin
@@ -32,10 +32,10 @@
 * Refactor product search
 * Gem upgrades
 
-###1.4.3 2013-02-04
+### 1.4.3 2013-02-04
 * bug fixes creating product
 
-###1.4.2 2013-02-03
+### 1.4.2 2013-02-03
 * pagination has less duplication
 * make UI look better in the admin and Customer facing site
 * random bugs
@@ -45,15 +45,15 @@
 * Make it dead simple to move to AWS/Heroku
 * Change implementation of updating addresses to inactivate old addresses
 
-###1.4.1 2013-01-13
+### 1.4.1 2013-01-13
 * Remove the remaining Blueprint CSS
 
-###1.4.0 2013-01-11
+### 1.4.0 2013-01-11
 * Added ZURB to customer facing site
 * remove blueprint CSS
 * Rails 3.2.11 security fix all good
 
-###1.3.0 2013-01-04
+### 1.3.0 2013-01-04
 * better css in admin
 * Sales
 * Refactored Coupon admin page
@@ -64,16 +64,16 @@
 * Use Setting instead of config.yml
 * documented the models better
 
-###1.2.1 2012-09-08
+### 1.2.1 2012-09-08
 * bug in admin properties
 
-###1.2.0 2012-09-08
+### 1.2.0 2012-09-08
 * HUGE Admin redesign (DEAN PERRY)  Thank you!
 * Deals
 * Support for future rails 4.0 deprecations
 * BUG fixes
 
-###1.1.0 2012-06-26
+### 1.1.0 2012-06-26
 * Add Deals (Buy 5 get 6th for 50% off)
 * Change TaxStatus to TaxCategory
 * More fulfillment functionality (create new shipment if it hasn't been created)
@@ -83,11 +83,11 @@
 * BUG - Name regex
 * BUG creditcard months should be all months
 
-###1.0.0 2012-02-14
+### 1.0.0 2012-02-14
 
 * Small bug with saving default address not saving correctly
 
-###1.0.0rc3 2012-02-12
+### 1.0.0rc3 2012-02-12
 
 * Better looking MyAccounts Section
 * Prevent careless deleting of ShippingZones/rate/tax info/brand
@@ -99,7 +99,7 @@
 * Clean out Gems
 * better Readme
 
-###1.0.0rc2 2012-01-21
+### 1.0.0rc2 2012-01-21
 
 * Bug Fix: RMA process broken link
 * remove jqGrid and replaced with normal rails helpers
@@ -108,7 +108,7 @@
 * updated gems (cancan, Zentest)
 * asset pipeline needed updates during production to precompile
 
-###1.0.0rc1 2012-01-16
+### 1.0.0rc1 2012-01-16
 
 * Bug Fix: Updating roles
 * Bug Fix: Shipping methods in checkout process
@@ -118,7 +118,7 @@
 * redirect after login (if you were required to login)
 * readme updates
 
-###0.10.0 2011-12-04
+### 0.10.0 2011-12-04
 
 * Added wizard to create a product
 * css / prettier buttons in admin
@@ -129,16 +129,16 @@
 * easier creation of variants
 * default meta data
 
-###0.9.2 2011-11-24
+### 0.9.2 2011-11-24
 
 * Add VAT support
 
-###0.9.1 2011-11-23
+### 0.9.1 2011-11-23
 
 * Updated Products workflow to be multistep
 * only show active products
 
-###0.9.0 2011-11-21
+### 0.9.0 2011-11-21
 
 * Readme improvements
 * removed Solr as a requirement
@@ -148,28 +148,28 @@
 * various bugs
 * quick setup for evaluation
 
-###0.9.0rc1 2011-11-12
+### 0.9.0rc1 2011-11-12
 
 * CHANGED admin cart to look like the regular cart
 * bugs in checkout process
 * starting to remove formtastic
 
-###0.8.0 2011-11-02
+### 0.8.0 2011-11-02
 
 * Better shipments and fulfillment UI
 * remove unused code/views
 * upgrade to rails 3.1
 * upgrade most gems to the current versions
 
-###0.7.0 2011-07-30
+### 0.7.0 2011-07-30
 
 * Inventory is now its own model...  TODO move inventory methods to the correct model(from variants)
 
-###0.6.1 2011-05-10
+### 0.6.1 2011-05-10
 
 * description_markup is required for tests to pass (validates presence)
 
-###0.6.0 2011-05-09
+### 0.6.0 2011-05-09
 
 * Description of products use bluecloth so you can easily create HTML.
 * bug fix in shipping zones
@@ -177,7 +177,7 @@
 * change users to active
 * password field showed password fixed bug
 
-###0.5.0 2011-04-04
+### 0.5.0 2011-04-04
 
 * Smarter error messages
 * switch to dalli for memcached
@@ -189,26 +189,26 @@
 * Date parsing works like ruby 1.8.7
 * code clean up
 
-###0.4.0 2011-01-22
+### 0.4.0 2011-01-22
 
 * Store Credits can be use to purchase items
 * UI improvements
 * Much better Cart
 * View products by product_type
 
-###0.3.0 2010-12-30
+### 0.3.0 2010-12-30
 
 * YARD docs complete
 * admin grid pagination fix
 
-###0.2.0 2010-12-26
+### 0.2.0 2010-12-26
 
 * more YARD docs
 * completed admin_grid tests
 * better looking home page
 * no_image has many sizes now
 
-###00.01.04 2010-12-19
+### 00.01.04 2010-12-19
 
 * added YARD docs
 * bug fixed for selecting countries that are available
@@ -218,12 +218,12 @@
 * use only taxrates for available countries
 * better look an feel on the header
 
-###00.01.03 2010-12-01
+### 00.01.03 2010-12-01
 
 * able to print a basic invoice for an order
 * installed prawnto
 
-###00.01.02 2010-11-21
+### 00.01.02 2010-11-21
 
 * able to add countries specific states
 * tax rates can be configured per the country of choice
@@ -231,11 +231,11 @@
 * bug fixes for bad pages to add admin forms
 * bug fix - welcome page blows up if there aren't any products
 
-###00.01.01 2010-11-12
+### 00.01.01 2010-11-12
 
 * connected Purchase Order to double entry accounting system
 * fixed bugs with editing purchase order screen was a blank screen
 
-###0.1.0 2010-11-12
+### 0.1.0 2010-11-12
 
 * Initial version.  This public repo had not been tag with a version yet.  Required for logistics.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#ROR Ecommerce
+# ROR Ecommerce
 
-##Project Overview
+## Project Overview
 
 Please create a ticket on github if you have issues.
 They will be addressed ASAP.
@@ -29,14 +29,14 @@ If you don't like something, you are free to just change it like you would in an
 We will always need help with UI, documentation, and code, so feel free to pitch in.
 To get started, simply fork this repo, make *any* changes (big or small), and create a pull request.
 
-##DEMO
+## DEMO
 
 Take a look at [The Demo](https://ror-e.herokuapp.com).
 The login name is test@ror-e.com with a password => test123
 
 NOTE: Given that everyone has admin rights to the demo it is frequently looking less than "beautiful".
 
-##Getting Started
+## Getting Started
 
 Please feel free to ask/answer questions in our [Google Group](http://groups.google.com/group/ror_ecommerce).
 
@@ -101,7 +101,7 @@ This is needed for using sendgrid on heroku(config/initializers/mail.rb):
     heroku config:add SENDGRID_PASSWORD=xxxxxxxxxxxxxxx
 
 
-##Quick Evaluation
+## Quick Evaluation
 
 If you just want to see what ror_ecommerce looks like, before you enter any products into the database, run the following command:
 
@@ -113,7 +113,7 @@ You should now have a minimal dataset, and be able to see a demo of the various 
 Note: make sure you have `config/settings.yml` set up correctly before you try to checkout.
 Also, please take a look at [The 15 minute e-commerce video](http://www.ror-e.com/info/videos/7).
 
-##ImageMagick and rMagick on OS X 10.8
+## ImageMagick and rMagick on OS X 10.8
 ------------------------------------
 
 If installing rMagick on OS X 10.8 and using Homebrew to install ImageMagick, you will need to symlink across some files or rMagick will not be able to build.
@@ -127,13 +127,13 @@ Do the following in the case of a Homebrew installed ImageMagick(and homebrew ha
 
     * you may need to change the version path if the imagemagick has been updated
 
-##YARDOCS
+## YARDOCS
 
 If you would like to read the docs, you can generate them with the following command:
 
     yardoc --no-private --protected app/models/*.rb
 
-####Payment Gateways
+#### Payment Gateways
 
 First, create `config/settings.yml` and change the encryption key and paypal/auth.net information.
 You can also change `config/settings.yml.example` to `config/settings.yml` until you get your real info.
@@ -166,7 +166,7 @@ Into:
 Paperclip.options[:command_path] = "/usr/bin"
 ```
 
-##Adding Dalli For Cache and the Session Store
+## Adding Dalli For Cache and the Session Store
 
 While optional, for a speedy site, using memcached is a good idea.
 
@@ -177,7 +177,7 @@ If you're on a Mac, the easiest way to install Memcached is to use [homebrew](ht
 
     memcached -vv
 
-####To Turn On the Dalli Cookie Store
+#### To Turn On the Dalli Cookie Store
 
 Remove the cookie store on line one of `config/initializers/session_store.rb`.
 In your Gemfile add:
@@ -197,7 +197,7 @@ require 'action_dispatch/middleware/session/dalli_store'
 Hadean::Application.config.session_store :dalli_store, :key => '_hadean_session_ugrdr6765745ce4vy'
 ```
 
-####To Turn On the Dalli Cache Store
+#### To Turn On the Dalli Cache Store
 
 It is also recommended to change the cache store in config/environments/*.rb
 
@@ -242,12 +242,12 @@ You need to run `rake sunspot:solr:start`, or remove Solr completely.
 
 Remember to run `rake sunspot:reindex` before doing your search if you already have data in the DB
 
-##TODO:
+## TODO:
 
 * more documentation
 
 
-##SETUP assets on S3 with CORS
+## SETUP assets on S3 with CORS
 
 Putting assets on S3 can cause issues with FireFox/IE.  You can read about the issue if you search for "S3 & CORS".  Basically FF & IE are keeping things more secure but in the process you are required to do some setup.
 
@@ -280,11 +280,11 @@ If you have many variants with the same image don't bother with an image group, 
 
 Use ImageGroups for something like shoes. Lets say you have 3 colors, and each color has 10 sizes. You would create 3 images groups (one for each color). The image for each size would be the same and hence each variant would be associated to the same image_group for a given color.
 
-##Author
+## Author
 
 RoR Ecommerce was created by David Henner. [Contributors](https://github.com/drhenner/ror_ecommerce/blob/master/Contributors.md).
 
-##FYI:
+## FYI:
 
 Shipping categories are categories based off price:
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-##This is a random list of thoughts that I would like todo.
+## This is a random list of thoughts that I would like todo.
 
 add tax and not adding tax
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
